### PR TITLE
biscuit(parser): allow more slice names

### DIFF
--- a/biscuit/src/Auth/Biscuit/Datalog/AST.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/AST.hs
@@ -98,11 +98,11 @@ type family VariableType (inSet :: IsWithinSet) (pof :: PredicateOrFact) where
   VariableType 'NotWithinSet 'InPredicate = Text
   VariableType inSet          pof         = Void
 
-newtype Slice = Slice String
+newtype Slice = Slice Text
   deriving newtype (Eq, Show, Ord, IsString)
 
 instance Lift Slice where
-  lift (Slice name) = [| toTerm $(varE $ mkName name) |]
+  lift (Slice name) = [| toTerm $(varE $ mkName $ unpack name) |]
 #if MIN_VERSION_template_haskell(2,17,0)
   liftTyped = liftCode . unsafeTExpCoerce . lift
 #else

--- a/biscuit/test/Spec/Parser.hs
+++ b/biscuit/test/Spec/Parser.hs
@@ -75,7 +75,14 @@ termsGroupQQ = testGroup "Parse terms (in a QQ setting)"
   , testCase "Date" $ parseTermQQ "2019-12-02T13:49:53Z" @?=
         Right (LDate $ read "2019-12-02 13:49:53 UTC")
   , testCase "Variable" $ parseTermQQ "$1" @?= Right (Variable "1")
-  , testCase "Antiquote" $ parseTermQQ "${toto}" @?= Right (Antiquote "toto")
+  , testGroup "Antiquote"
+     [ testCase "Variable name" $ parseTermQQ "${toto2_'}" @?= Right (Antiquote "toto2_'")
+     , testCase "Leading underscore" $ parseTermQQ "${_toto}" @?= Right (Antiquote "_toto")
+     , testCase "`_` is reserved" $ parseTermQQ "${_}" @?= Left "Failed reading: empty"
+     , testCase "Variables are lower-cased" $ parseTermQQ "${Toto}" @?= Left "Failed reading: empty"
+     , testCase "_ is lower-case" $ parseTermQQ "${_Toto}" @?= Right (Antiquote "_Toto")
+     , testCase "unicode is allowed" $ parseTermQQ "${éllo}" @?= Right (Antiquote "éllo")
+     ]
   ]
 
 simpleFact :: TestTree

--- a/biscuit/test/Spec/Quasiquoter.hs
+++ b/biscuit/test/Spec/Quasiquoter.hs
@@ -38,10 +38,10 @@ basicRule = testCase "Basic rule" $
 
 antiquotedFact :: TestTree
 antiquotedFact = testCase "Sliced fact" $
-  let toto :: Text
-      toto = "test"
+  let toto2' :: Text
+      toto2' = "test"
       actual :: Fact
-      actual = [fact|right(${toto}, "read")|]
+      actual = [fact|right(${toto2'}, "read")|]
    in actual @?=
     Predicate "right" [ LString "test"
                       , LString "read"


### PR DESCRIPTION
Quoting the haskell report:

>  An identifier consists of a letter followed by zero or more letters, digits, underscores, and single quotes. Identifiers are lexically distinguished into two namespaces (Section 1.4): those that begin with a lower-case letter (variable identifiers) and those that begin with an upper-case letter (constructor identifiers). Identifiers are case sensitive: name, naMe, and Name are three distinct identifiers (the first two are variable identifiers, the last is a constructor identifier).
> Underscore, "_", is treated as a lower-case letter, and can occur wherever a lower-case letter can. However, "_" all by itself is a reserved identifier, used as wild card in patterns. Compilers that offer warnings for unused identifiers are encouraged to suppress such warnings for identifiers beginning with underscore. This allows programmers to use "_foo" for a parameter that they expect to be unused.