### PR TITLE
fix: use correct license identifier in file headers

### DIFF
--- a/biscuit/src/Auth/Biscuit.hs
+++ b/biscuit/src/Auth/Biscuit.hs
@@ -3,7 +3,7 @@
 {-|
   Module      : Auth.Biscuit
   Copyright   : © Clément Delafargue, 2021
-  License     : MIT
+  License     : BSD-3-Clause
   Maintainer  : clement@delafargue.name
   Haskell implementation for the Biscuit token.
 -}

--- a/biscuit/src/Auth/Biscuit/Datalog/AST.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/AST.hs
@@ -20,7 +20,7 @@
 {-|
   Module      : Auth.Biscuit.Datalog.AST
   Copyright   : © Clément Delafargue, 2021
-  License     : MIT
+  License     : BSD-3-Clause
   Maintainer  : clement@delafargue.name
   The Datalog elements
 -}

--- a/biscuit/src/Auth/Biscuit/Datalog/Executor.hs
+++ b/biscuit/src/Auth/Biscuit/Datalog/Executor.hs
@@ -10,7 +10,7 @@
 {-|
   Module      : Auth.Biscuit.Datalog.Executor
   Copyright   : © Clément Delafargue, 2021
-  License     : MIT
+  License     : BSD-3-Clause
   Maintainer  : clement@delafargue.name
   The Datalog engine, tasked with deriving new facts from existing facts and rules, as well as matching available facts against checks and policies
 -}

--- a/biscuit/src/Auth/Biscuit/Proto.hs
+++ b/biscuit/src/Auth/Biscuit/Proto.hs
@@ -6,7 +6,7 @@
 {-|
   Module      : Auth.Biscuit.Proto
   Copyright   : © Clément Delafargue, 2021
-  License     : MIT
+  License     : BSD-3-Clause
   Maintainer  : clement@delafargue.name
   Haskell data structures mapping the biscuit protobuf definitions
 -}

--- a/biscuit/src/Auth/Biscuit/ProtoBufAdapter.hs
+++ b/biscuit/src/Auth/Biscuit/ProtoBufAdapter.hs
@@ -8,7 +8,7 @@
 {-|
   Module      : Auth.Biscuit.Utils
   Copyright   : © Clément Delafargue, 2021
-  License     : MIT
+  License     : BSD-3-Clause
   Maintainer  : clement@delafargue.name
   Conversion functions between biscuit components and protobuf-encoded components
 -}

--- a/biscuit/src/Auth/Biscuit/Timer.hs
+++ b/biscuit/src/Auth/Biscuit/Timer.hs
@@ -1,7 +1,7 @@
 {-|
   Module      : Auth.Biscuit.Timer
   Copyright   : © Clément Delafargue, 2021
-  License     : MIT
+  License     : BSD-3-Clause
   Maintainer  : clement@delafargue.name
   Helper function making sure an IO action runs in an alloted time
 -}

--- a/biscuit/src/Auth/Biscuit/Token.hs
+++ b/biscuit/src/Auth/Biscuit/Token.hs
@@ -8,7 +8,7 @@
 {-|
   Module      : Auth.Biscuit.Token
   Copyright   : © Clément Delafargue, 2021
-  License     : MIT
+  License     : BSD-3-Clause
   Maintainer  : clement@delafargue.name
   Module defining the main biscuit-related operations
 -}

--- a/biscuit/src/Auth/Biscuit/Utils.hs
+++ b/biscuit/src/Auth/Biscuit/Utils.hs
@@ -3,7 +3,7 @@
 -- |
 --  Module      : Auth.Biscuit.Utils
 --  Copyright   : © Clément Delafargue, 2021
---  License     : MIT
+--  License     : BSD-3-Clause
 --  Maintainer  : clement@delafargue.name
 module Auth.Biscuit.Utils
   ( maybeToRight,


### PR DESCRIPTION
biscuit-haskell is licensed under BSD-3-Clause, not MIT